### PR TITLE
symbol_section_accessor::get_symbol(name) fixes

### DIFF
--- a/elfio/elfio_symbols.hpp
+++ b/elfio/elfio_symbols.hpp
@@ -76,13 +76,13 @@ class symbol_section_accessor
 
 //------------------------------------------------------------------------------
     bool
-    get_symbol( std::string&   name,
-                Elf64_Addr&    value,
-                Elf_Xword&     size,
-                unsigned char& bind,
-                unsigned char& type,
-                Elf_Half&      section_index,
-                unsigned char& other ) const
+    get_symbol( const std::string& name,
+                Elf64_Addr&        value,
+                Elf_Xword&         size,
+                unsigned char&     bind,
+                unsigned char&     type,
+                Elf_Half&          section_index,
+                unsigned char&     other ) const
     {
         bool ret = false;
 


### PR DESCRIPTION
Hi,

When using get_symbol(name), I noticed that it occasionally crashed if I was trying to get a nonexistent symbol.
Here is a test program that crashes on my system:

```
#include <elfio/elfio.hpp>
#include <string>
#include <cstdio>

using namespace std;
using namespace ELFIO;

int main(int argc, char* argv[]) {
    elfio elf;
    if(elf.load(argv[0])) {
        section* dynsym = elf.sections[".dynsym"];
        if (dynsym) {
            const symbol_section_accessor symtab(elf, dynsym);
            Elf64_Addr    offset;
            Elf_Xword     size;
            unsigned char bind  = 0;
            unsigned char type  = STT_NOTYPE;
            Elf_Half      section_index;
            unsigned char other;
            string name("crash");
            if (symtab.get_symbol(name, offset, size, bind,
                                  type, section_index, other))
            {
                printf("FOUND\n");
            } else {
                printf("NOT FOUND\n");
            }
        }
    }
}
```

And here is how it crashes:

```
Program received signal SIGSEGV, Segmentation fault.
0x000000000040314a in ELFIO::symbol_section_accessor::get_symbol (this=0x7fffffffdb30, 
    name=..., value=@0x7fffffffdb18: 6, size=@0x7fffffffdb20: 6361576, 
    bind=@0x7fffffffdb0b: 0 '\000', type=@0x7fffffffdb0c: 0 '\000', 
    section_index=@0x7fffffffdb0e: 0, other=@0x7fffffffdb0d: 127 '\177')
    at ./elfio/elfio_symbols.hpp:99
99                          ( 2 + nbucket + y ) * sizeof( Elf_Word ) );
(gdb) print y
$1 = 537936257
```

Notice how `y` has clearly gone out of bounds.

The first commit fixes the crash by checking `y` before indexing the chain table.

The second commit just makes the `name` parameter const.

Cheers,
Semi
