### PR TITLE
Fix a couple off-by-one errors in the add_note() function.

### DIFF
--- a/elfio/elfio_note.hpp
+++ b/elfio/elfio_note.hpp
@@ -66,7 +66,7 @@ class note_section_accessor
              namesz + descSize > max_name_size ) {
             return false;
         }
-        name.assign( pData + 3 * sizeof( Elf_Word ), namesz );
+        name.assign( pData + 3 * sizeof( Elf_Word ), namesz - 1);
         if ( 0 == descSize ) {
             desc = 0;
         }

--- a/elfio/elfio_note.hpp
+++ b/elfio/elfio_note.hpp
@@ -71,10 +71,7 @@ class note_section_accessor
             desc = 0;
         }
         else {
-            int align = sizeof( Elf_Xword );
-            if ( elf_file.get_class() == ELFCLASS32 ) {
-                align = sizeof( Elf_Word );
-            }
+            int align = sizeof( Elf_Word );
             desc = const_cast<char*> ( pData + 3*sizeof( Elf_Word ) +
                                        ( ( namesz + align - 1 ) / align ) * align );
         }


### PR DESCRIPTION
```
commit cca7911cc48c4c1094a3a26d23c8a129952ff9a8
Author: Kevin Klues <klueska@gmail.com>
Date:   Sat Jul 2 10:24:08 2016 -0700

    Fixed alignment of 'desc' in add_note() function.
    
    The ELF spec specifically lists the alignment of the namez char[] to be
    4 bytes. To quote it:
    
    "Padding is present, if necessary, to ensure 4-byte alignment for the
    descriptor. Such padding is not included in namesz."
    
    However, the current implementation sets the alignment to either 4 or 8
    bytes depending on the class of the ELF file (CLASS32 or CLASS64). This
    commit fixes the alignment to only 4 bytes in all cases.

commit e3e0d6dbdb87d167ac1e4365b6db8b56dcb87678
Author: Kevin Klues <klueska@gmail.com>
Date:   Sat Jul 2 10:17:44 2016 -0700

    Fixed off-by-one error in 'name' of add_note() function.
    
    Previously, when assigning 'name' as a string, it's length was specified
    using the full length of 'namesz'. However, this length includes the
    trailing '\0' of the underlying char[]. This ultimately causes the C++
    string that is created to (incorrectly) contain the '\0' character as
    well. This leads to problems where e.g. the following will return false,
    even when 'name' itself actually contains the string "GNU\0":
    
      if (name == "GNU") {
        return true;
      }
      return false;
    
    To fix this, we should only include the length of the string minus the
    trailing '\0'.
```