### PR TITLE
resolve compiler warning by "-Wsign-compare"

### DIFF
--- a/elfio/elfio_dump.hpp
+++ b/elfio/elfio_dump.hpp
@@ -728,7 +728,7 @@ class dump
                 if ( dyn_no > 0 ) {
                     out << "Dynamic section (" << sec->get_name() << ")" << std::endl;
                     out << "[  Nr ] Tag              Name/Value" << std::endl;
-                    for ( int i = 0; i < dyn_no; ++i ) {
+                    for ( Elf_Xword i = 0; i < dyn_no; ++i ) {
                         Elf_Xword   tag   = 0;
                         Elf_Xword   value = 0;
                         std::string str;


### PR DESCRIPTION
Hi,
Thank you for sharing really handy library.
Compiler complains about comparing signed and unsigned integer.
This tiny patch resolves the warning.
Thanks,