### PR TITLE
elfio: don't cast away const qualifiers

### DIFF
--- a/elfio/elfio_note.hpp
+++ b/elfio/elfio_note.hpp
@@ -71,9 +71,9 @@ class note_section_accessor
         int align = sizeof( Elf_Word );
 
         const endianess_convertor& convertor = elf_file.get_convertor();
-        type = convertor( *(Elf_Word*)( pData + 2*align ) );
-        Elf_Word namesz = convertor( *(Elf_Word*)( pData ) );
-        descSize = convertor( *(Elf_Word*)( pData + sizeof( namesz ) ) );
+        type = convertor( *(const Elf_Word*)( pData + 2*align ) );
+        Elf_Word namesz = convertor( *(const Elf_Word*)( pData ) );
+        descSize = convertor( *(const Elf_Word*)( pData + sizeof( namesz ) ) );
         Elf_Word max_name_size = note_section->get_size() - note_start_positions[index];
         if ( namesz            > max_name_size ||
              namesz + descSize > max_name_size ) {
@@ -144,9 +144,9 @@ class note_section_accessor
         while ( current + 3*align <= size ) {
             note_start_positions.push_back( current );
             Elf_Word namesz = convertor(
-                            *(Elf_Word*)( data + current ) );
+                            *(const Elf_Word*)( data + current ) );
             Elf_Word descsz = convertor(
-                            *(Elf_Word*)( data + current + sizeof( namesz ) ) );
+                            *(const Elf_Word*)( data + current + sizeof( namesz ) ) );
 
             current += 3*sizeof( Elf_Word ) +
                        ( ( namesz + align - 1 ) / align ) * align +

--- a/elfio/elfio_symbols.hpp
+++ b/elfio/elfio_symbols.hpp
@@ -87,17 +87,17 @@ class symbol_section_accessor
         bool ret = false;
 
         if ( 0 != get_hash_table_index() ) {
-            Elf_Word nbucket = *(Elf_Word*)hash_section->get_data();
-            Elf_Word nchain  = *(Elf_Word*)( hash_section->get_data() +
+            Elf_Word nbucket = *(const Elf_Word*)hash_section->get_data();
+            Elf_Word nchain  = *(const Elf_Word*)( hash_section->get_data() +
                                    sizeof( Elf_Word ) );
             Elf_Word val     = elf_hash( (const unsigned char*)name.c_str() );
 
-            Elf_Word y   = *(Elf_Word*)( hash_section->get_data() +
+            Elf_Word y   = *(const Elf_Word*)( hash_section->get_data() +
                                ( 2 + val % nbucket ) * sizeof( Elf_Word ) );
             std::string   str;
             get_symbol( y, str, value, size, bind, type, section_index, other );
             while ( str != name && STN_UNDEF != y && y < nchain ) {
-                y = *(Elf_Word*)( hash_section->get_data() +
+                y = *(const Elf_Word*)( hash_section->get_data() +
                         ( 2 + nbucket + y ) * sizeof( Elf_Word ) );
                 get_symbol( y, str, value, size, bind, type, section_index, other );
             }

--- a/elfio/elfio_utils.hpp
+++ b/elfio/elfio_utils.hpp
@@ -174,7 +174,7 @@ class endianess_convertor {
     get_host_encoding() const
     {
         static const int tmp = 1;
-        if ( 1 == *(char*)&tmp ) {
+        if ( 1 == *(const char*)&tmp ) {
             return ELFDATA2LSB;
         }
         else {


### PR DESCRIPTION
Don't cast away const qualifiers when accessing const data (e.g. section
data). This fixes the warnings such as the following when compiling with
GCC and the -Wcast-qual flag set:

warning: cast from type ‘const char*’ to type ‘ELFIO::Elf_Word* {aka unsigned int*}’ casts away qualifiers [-Wcast-qual]