### PR TITLE
elfio_note: fix MSVC compiler warning

### DIFF
--- a/elfio/elfio_note.hpp
+++ b/elfio/elfio_note.hpp
@@ -74,7 +74,7 @@ class note_section_accessor
         type = convertor( *(const Elf_Word*)( pData + 2*align ) );
         Elf_Word namesz = convertor( *(const Elf_Word*)( pData ) );
         descSize = convertor( *(const Elf_Word*)( pData + sizeof( namesz ) ) );
-        Elf_Word max_name_size = note_section->get_size() - note_start_positions[index];
+        Elf_Xword max_name_size = note_section->get_size() - note_start_positions[index];
         if ( namesz            > max_name_size ||
              namesz + descSize > max_name_size ) {
             return false;


### PR DESCRIPTION
Fix the following MSVC compiler warning:

elfio/elfio_note.hpp(77): warning C4267: 'initializing' : conversion from 'size_t' to 'ELFIO::Elf_Word', possible loss of data

by changing the type of max_name_sizei to Elf_Xword, as
note_secton->get_size() returns Elf_Xword and note_start_positions also
contains members of type Elf_Xword.