### PR TITLE
Better support for read-only ELF access

### DIFF
--- a/elfio/elfio.hpp
+++ b/elfio/elfio.hpp
@@ -853,6 +853,16 @@ class elfio
         }
 
 //------------------------------------------------------------------------------
+        std::vector<section*>::const_iterator begin() const {
+            return parent->sections_.cbegin();
+        }
+
+//------------------------------------------------------------------------------
+        std::vector<section*>::const_iterator end() const {
+            return parent->sections_.cend();
+        }
+
+//------------------------------------------------------------------------------
       private:
         elfio* parent;
     } sections;
@@ -895,6 +905,16 @@ class elfio
 //------------------------------------------------------------------------------
         std::vector<segment*>::iterator end() {
             return parent->segments_.end();
+        }
+
+//------------------------------------------------------------------------------
+        std::vector<segment*>::const_iterator begin() const {
+            return parent->segments_.cbegin();
+        }
+
+//------------------------------------------------------------------------------
+        std::vector<segment*>::const_iterator end() const {
+            return parent->segments_.cend();
         }
 
 //------------------------------------------------------------------------------

--- a/elfio/elfio_dynamic.hpp
+++ b/elfio/elfio_dynamic.hpp
@@ -26,13 +26,14 @@ THE SOFTWARE.
 namespace ELFIO {
 
 //------------------------------------------------------------------------------
-class dynamic_section_accessor
+template< class S >
+class dynamic_section_accessor_template
 {
   public:
 //------------------------------------------------------------------------------
-    dynamic_section_accessor( const elfio& elf_file_, section* section_ ) :
-                              elf_file( elf_file_ ),
-                              dynamic_section( section_ )
+    dynamic_section_accessor_template( const elfio& elf_file_, S* section_ ) :
+                                       elf_file( elf_file_ ),
+                                       dynamic_section( section_ )
     {
     }
 
@@ -245,8 +246,11 @@ class dynamic_section_accessor
 //------------------------------------------------------------------------------
   private:
     const elfio& elf_file;
-    section*     dynamic_section;
+    S*           dynamic_section;
 };
+
+using dynamic_section_accessor = dynamic_section_accessor_template<section>;
+using const_dynamic_section_accessor = dynamic_section_accessor_template<const section>;
 
 } // namespace ELFIO
 

--- a/elfio/elfio_note.hpp
+++ b/elfio/elfio_note.hpp
@@ -38,12 +38,13 @@ namespace ELFIO {
 //------------------------------------------------------------------------------
 
 //------------------------------------------------------------------------------
-class note_section_accessor
+template< class S >
+class note_section_accessor_template
 {
   public:
 //------------------------------------------------------------------------------
-    note_section_accessor( const elfio& elf_file_, section* section_ ) :
-                           elf_file( elf_file_ ), note_section( section_ )
+    note_section_accessor_template( const elfio& elf_file_, S* section_ ) :
+                                    elf_file( elf_file_ ), note_section( section_ )
     {
         process_section();
     }
@@ -157,9 +158,12 @@ class note_section_accessor
 //------------------------------------------------------------------------------
   private:
     const elfio&           elf_file;
-    section*               note_section;
+    S*                     note_section;
     std::vector<Elf_Xword> note_start_positions;
 };
+
+using note_section_accessor = note_section_accessor_template<section>;
+using const_note_section_accessor = note_section_accessor_template<const section>;
 
 } // namespace ELFIO
 

--- a/elfio/elfio_relocation.hpp
+++ b/elfio/elfio_relocation.hpp
@@ -73,13 +73,14 @@ template<> struct get_sym_and_type< Elf64_Rela >
 
 
 //------------------------------------------------------------------------------
-class relocation_section_accessor
+template< class S >
+class relocation_section_accessor_template
 {
   public:
 //------------------------------------------------------------------------------
-    relocation_section_accessor( const elfio& elf_file_, section* section_ ) :
-                                 elf_file( elf_file_ ),
-                                 relocation_section( section_ )
+    relocation_section_accessor_template( const elfio& elf_file_, S* section_ ) :
+                                          elf_file( elf_file_ ),
+                                          relocation_section( section_ )
     {
     }
 
@@ -361,8 +362,11 @@ class relocation_section_accessor
 //------------------------------------------------------------------------------
   private:
     const elfio& elf_file;
-    section*     relocation_section;
+    S*           relocation_section;
 };
+
+using relocation_section_accessor = relocation_section_accessor_template<section>;
+using const_relocation_section_accessor = relocation_section_accessor_template<const section>;
 
 } // namespace ELFIO
 

--- a/elfio/elfio_strings.hpp
+++ b/elfio/elfio_strings.hpp
@@ -30,12 +30,13 @@ THE SOFTWARE.
 namespace ELFIO {
 
 //------------------------------------------------------------------------------
-class string_section_accessor
+template< class S >
+class string_section_accessor_template
 {
   public:
 //------------------------------------------------------------------------------
-    string_section_accessor( section* section_ ) :
-                             string_section( section_ )
+    string_section_accessor_template( S* section_ ) :
+                                      string_section( section_ )
     {
     }
 
@@ -88,8 +89,11 @@ class string_section_accessor
 
 //------------------------------------------------------------------------------
   private:
-    section* string_section;
+    S* string_section;
 };
+
+using string_section_accessor = string_section_accessor_template<section>;
+using const_string_section_accessor = string_section_accessor_template<const section>;
 
 } // namespace ELFIO
 

--- a/elfio/elfio_symbols.hpp
+++ b/elfio/elfio_symbols.hpp
@@ -26,13 +26,14 @@ THE SOFTWARE.
 namespace ELFIO {
 
 //------------------------------------------------------------------------------
-class symbol_section_accessor
+template< class S >
+class symbol_section_accessor_template
 {
   public:
 //------------------------------------------------------------------------------
-    symbol_section_accessor( const elfio& elf_file_, section* symbol_section_ ) :
-                             elf_file( elf_file_ ),
-                             symbol_section( symbol_section_ )
+    symbol_section_accessor_template( const elfio& elf_file_, S* symbol_section_ ) :
+                                      elf_file( elf_file_ ),
+                                      symbol_section( symbol_section_ )
     {
         find_hash_section();
     }
@@ -268,10 +269,13 @@ class symbol_section_accessor
 //------------------------------------------------------------------------------
   private:
     const elfio&   elf_file;
-    section*       symbol_section;
+    S*             symbol_section;
     Elf_Half       hash_section_index;
     const section* hash_section;
 };
+
+using symbol_section_accessor = symbol_section_accessor_template<section>;
+using const_symbol_section_accessor = symbol_section_accessor_template<const section>;
 
 } // namespace ELFIO
 


### PR DESCRIPTION
For read-only access I'd like to be able to use a `const ELFIO::elfio` and `const _accessor`'s. The former was mostly available but missing constant iterator access. The latter required converting accessors to accessor templates which store a `section*` when write-access functions are required but a `const section*` when a constant accessor is needed.