### PR TITLE
Fix two gcc -Wignored-qualifiers warnings

### DIFF
--- a/elfio/elfio_section.hpp
+++ b/elfio/elfio_section.hpp
@@ -47,7 +47,7 @@ class section
     ELFIO_GET_SET_ACCESS_DECL( Elf_Word,    name_string_offset );
     ELFIO_GET_ACCESS_DECL    ( Elf64_Off,   offset             );
     size_t stream_size;
-    const size_t get_stream_size() const 
+    size_t get_stream_size() const
      {
 	return stream_size;
      }

--- a/elfio/elfio_segment.hpp
+++ b/elfio/elfio_segment.hpp
@@ -95,8 +95,8 @@ class segment_impl : public segment
     size_t stream_size;
 
 //------------------------------------------------------------------------------
-    const size_t 
-    get_stream_size() const 
+    size_t
+    get_stream_size() const
     {
        return stream_size;
     }


### PR DESCRIPTION
Fix the following two gcc warnings:

elfio/elfio_section.hpp:50:36: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
     const size_t get_stream_size() const
                                    ^
elfio/elfio_segment.hpp:99:23: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
     get_stream_size() const