### PR TITLE
Add overload to elfio::save which accepts std::ostream

### DIFF
--- a/elfio/elf_types.hpp
+++ b/elfio/elf_types.hpp
@@ -827,7 +827,7 @@ struct Elf64_Rela {
 
 #define ELF64_R_SYM(i)    ((i)>>32)
 #define ELF64_R_TYPE(i)   ((i)&0xffffffffL)
-#define ELF64_R_INFO(s,t) ((((int64_t)s)<<32)+((t)&0xffffffffL))
+#define ELF64_R_INFO(s,t) ((((int64_t)(s))<<32)+((t)&0xffffffffL))
 
 // Dynamic structure
 struct Elf32_Dyn {

--- a/elfio/elfio.hpp
+++ b/elfio/elfio.hpp
@@ -113,9 +113,9 @@ class elfio
     {
         clean();
 
-	unsigned char e_ident[EI_NIDENT];
-	// Read ELF file signature
-	stream.read( reinterpret_cast<char*>( &e_ident ), sizeof( e_ident ) );
+        unsigned char e_ident[EI_NIDENT];
+        // Read ELF file signature
+        stream.read( reinterpret_cast<char*>( &e_ident ), sizeof( e_ident ) );
 
         // Is it ELF file?
         if ( stream.gcount() != sizeof( e_ident ) ||
@@ -721,10 +721,10 @@ class elfio
                 else if (!section_generated[index] && !sec->is_address_initialized() ) {
                     // If no address has been specified then only the section
                     // alignment constraint has to be matched
-					Elf_Xword align = sec->get_addr_align();
-					if (align == 0) {
-						align = 1;
-					}
+                    Elf_Xword align = sec->get_addr_align();
+                    if (align == 0) {
+                        align = 1;
+                    }
                     Elf64_Off error = current_file_pos % align;
                     secAlign = ( align - error ) % align;
                 }

--- a/elfio/elfio.hpp
+++ b/elfio/elfio.hpp
@@ -148,9 +148,19 @@ class elfio
 //------------------------------------------------------------------------------
     bool save( const std::string& file_name )
     {
-        std::ofstream f( file_name.c_str(), std::ios::out | std::ios::binary );
+        std::ofstream stream;
+        stream.open( file_name.c_str(), std::ios::out | std::ios::binary );
+        if ( !stream ) {
+            return false;
+        }
 
-        if ( !f || !header) {
+        return save(stream);
+    }
+
+//------------------------------------------------------------------------------
+    bool save( std::ostream &stream )
+    {
+        if ( !stream || !header) {
             return false;
         }
 
@@ -174,11 +184,9 @@ class elfio
         is_still_good = is_still_good && layout_sections_without_segments();
         is_still_good = is_still_good && layout_section_table();
 
-        is_still_good = is_still_good && save_header( f );
-        is_still_good = is_still_good && save_sections( f );
-        is_still_good = is_still_good && save_segments( f );
-
-        f.close();
+        is_still_good = is_still_good && save_header( stream );
+        is_still_good = is_still_good && save_sections( stream );
+        is_still_good = is_still_good && save_segments( stream );
 
         return is_still_good;
     }
@@ -482,13 +490,13 @@ class elfio
     }
 
 //------------------------------------------------------------------------------
-    bool save_header( std::ofstream& f )
+    bool save_header( std::ostream& f )
     {
         return header->save( f );
     }
 
 //------------------------------------------------------------------------------
-    bool save_sections( std::ofstream& f )
+    bool save_sections( std::ostream& f )
     {
         for ( unsigned int i = 0; i < sections_.size(); ++i ) {
             section *sec = sections_.at(i);
@@ -503,7 +511,7 @@ class elfio
     }
 
 //------------------------------------------------------------------------------
-    bool save_segments( std::ofstream& f )
+    bool save_segments( std::ostream& f )
     {
         for ( unsigned int i = 0; i < segments_.size(); ++i ) {
             segment *seg = segments_.at(i);


### PR DESCRIPTION
The main change is stated in the title. Also, there are small improvements in the other two commits. The motivation for this overload is that we sometimes need to directly transfer ELF data structures to e.g. sockets, avoiding saving to file.