### PR TITLE
Avoid warning about initialization reorder (-Wreorder) on GCC

### DIFF
--- a/elfio/elfio_segment.hpp
+++ b/elfio/elfio_segment.hpp
@@ -69,7 +69,7 @@ class segment_impl : public segment
   public:
 //------------------------------------------------------------------------------
     segment_impl( endianess_convertor* convertor_ ) :
-        convertor( convertor_ ), stream_size( 0 ), index( 0 ), data( 0 )
+		stream_size( 0 ), index( 0 ), data( 0 ), convertor( convertor_ )
     {
         is_offset_set = false;
         std::fill_n( reinterpret_cast<char*>( &ph ), sizeof( ph ), '\0' );


### PR DESCRIPTION
This warning is enabled by, e.g., -Wall. Compiled on GCC 7.3