### PR TITLE
Fixed some warnings from Cppcheck.

### DIFF
--- a/ELFIOTest/ELFIOTest.cpp
+++ b/ELFIOTest/ELFIOTest.cpp
@@ -74,7 +74,7 @@ checkSection( const section* sec,
 ////////////////////////////////////////////////////////////////////////////////
 void
 checkSection( const section* sec,
-              std::string name,
+              const std::string &name,
               Elf_Word    type,
               Elf_Xword   flags,
               Elf64_Addr  address,

--- a/examples/RelocationTable/RelocationTable.cpp
+++ b/examples/RelocationTable/RelocationTable.cpp
@@ -35,11 +35,11 @@ int main( int, char* argv[] )
         if ( 0 < nNum ) {
             std::printf( "\nSection name: %s\n", pSec->GetName().c_str() );
             std::printf( "  Num Type Offset   Addend    Calc   SymValue   SymName\n" );
-            for ( Elf_Xword i = 0; i < nNum; ++i ) {
-                pRel->GetEntry( i, offset, symbolValue, symbolName,
+            for ( Elf_Xword j = 0; j < nNum; ++j ) {
+                pRel->GetEntry( j, offset, symbolValue, symbolName,
                                 type, addend, calcValue );
                 std::printf( "[%4llx] %02x %08llx %08llx %08llx %08llx %s\n",
-                             i, type, offset,
+                             j, type, offset,
                              addend, calcValue,
                              symbolValue, symbolName.c_str() );
             }


### PR DESCRIPTION
This fixes two warnings brought up by Cppcheck:

```
[ELFIO/ELFIOTest/ELFIOTest.cpp:77]: (performance) Function parameter 'name' should be passed by const reference.
[ELFIO/examples/RelocationTable/RelocationTable.cpp:16] -> [ELFIO/examples/RelocationTable/RelocationTable.cpp:38]: (style) Local variable 'i' shadows outer variable
```