### PR TITLE
Added get_symbol by value and generic linear search

### DIFF
--- a/elfio/elfio.hpp
+++ b/elfio/elfio.hpp
@@ -33,11 +33,13 @@ THE SOFTWARE.
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <functional>
 #include <algorithm>
 #include <vector>
 #include <deque>
 #include <iterator>
 #include <typeinfo>
+#include <cassert>
 
 #include <elfio/elf_types.hpp>
 #include <elfio/elfio_utils.hpp>


### PR DESCRIPTION
This is something I found useful for creating e.g. backtraces. 

I'm added a generic search over raw symbol entries using `std::function`, in order to not have to lookup and produce all the `std::strings` etc. for each search. 

I've only tested this locally in an application I'm building for work, so please let me know how / if you want me to update any tests or examples.
