### PR TITLE
Add cmake install support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,106 @@
-cmake_minimum_required(VERSION 3.12.4)
+cmake_minimum_required(VERSION 3.12)
 
-project(elfio)
-set(CMAKE_CXX_STANDARD 17)
+# Detect if we are the top level CMakeLists.txt or are we included in some
+# other project
+if(NOT DEFINED PROJECT_NAME)
+  set(IS_TOP_PROJECT TRUE)
+endif()
 
-add_subdirectory(examples/add_section)
-add_subdirectory(examples/anonymizer)
-add_subdirectory(examples/elfdump)
-add_subdirectory(examples/tutorial)
-add_subdirectory(examples/write_obj)
-add_subdirectory(examples/writer)
-add_subdirectory(examples/c_wrapper)
+# Turn this on in order to build elfio examples
+option(ELFIO_BUILD_EXAMPLES "Build ELFIO examples" OFF)
+
+# Turns this on in order to build tests
+option(ELFIO_BUILD_TESTS    "Build ELFIO tests" OFF)
+
+# Read version from header file
+set(version_header "elfio/elfio_version.hpp")
+file(READ ${version_header} ver)
+string(REGEX MATCH "#define ELFIO_VERSION \"([0-9\.]+)\"" _ ${ver})
+if (NOT CMAKE_MATCH_1)
+    message(FATAL_ERROR "Unable to parse version from ${version_header}")
+endif()
+set(version ${CMAKE_MATCH_1})
+
+# Use configure_file to make configure step depend on elfio_version.hpp
+configure_file(${version_header} ${CMAKE_CURRENT_BINARY_DIR}/elfio_version.hpp.copy COPYONLY)
+
+project(elfio VERSION ${version} LANGUAGES C CXX)
+
+include(GNUInstallDirs)
+
+# Create a header only CMake target for elfio
+add_library(elfio INTERFACE)
+add_library(elfio::elfio ALIAS elfio)
+
+target_include_directories(
+    elfio
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+if (ELFIO_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+if (ELFIO_BUILD_TESTS AND IS_TOP_PROJECT)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+# If this is the top level project, add in logic to install elfio
+if (IS_TOP_PROJECT)
+    include(CMakePackageConfigHelpers)
+
+    # Create a file that includes the current project version. This will be
+    # installed with the elfio CMake package.
+    write_basic_package_version_file(
+        "${PROJECT_NAME}ConfigVersion.cmake"
+        VERSION
+            ${PROJECT_VERSION}
+        COMPATIBILITY
+            SameMajorVersion)
+    
+    # Create the default ${PROJECT_NAME}Config.cmake file which will be
+    # installed and found by calls to `find_package(elfio)`.
+    configure_package_config_file(
+        "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
+        "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+        INSTALL_DESTINATION
+            ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+
+    # Install the previously generated "config" and "version" files
+    install(
+        FILES
+            "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+            "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+        DESTINATION
+            ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+
+    # Install the entire local `elfio` directory to the include directory
+    install(
+        DIRECTORY
+            elfio
+        DESTINATION
+            ${CMAKE_INSTALL_INCLUDEDIR})
+
+    # Create a ${PROJECT_NAME}Targets.cmake file that is referenced by the
+    # ${PROJECT_NAME}Config.cmake file and includes the target information
+    # needed to compile/link against all targets exported under the
+    # ${PROJECT_NAME}_Targets export
+    install(
+        EXPORT
+            ${PROJECT_NAME}_Targets
+        FILE
+            ${PROJECT_NAME}Targets.cmake
+        NAMESPACE
+            ${PROJECT_NAME}::
+        DESTINATION
+            ${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME}/cmake)
+
+    # Add the elfio target to the ${PROJECT_NAME}_Targets export
+    install(
+        TARGETS
+            elfio
+        EXPORT
+            ${PROJECT_NAME}_Targets)
+endif()

--- a/cmake/elfioConfig.cmake.in
+++ b/cmake/elfioConfig.cmake.in
@@ -1,0 +1,5 @@
+# Basic CMake package config file
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_subdirectory(add_section)
+add_subdirectory(anonymizer)
+add_subdirectory(elfdump)
+add_subdirectory(tutorial)
+add_subdirectory(write_obj)
+add_subdirectory(writer)
+add_subdirectory(c_wrapper)

--- a/examples/add_section/CMakeLists.txt
+++ b/examples/add_section/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 add_executable(add_section add_section.cpp)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR})
+target_link_libraries(add_section PRIVATE elfio::elfio)

--- a/examples/anonymizer/CMakeLists.txt
+++ b/examples/anonymizer/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 add_executable(anonymizer anonymizer.cpp)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR})
+target_link_libraries(anonymizer PRIVATE elfio::elfio)

--- a/examples/c_wrapper/CMakeLists.txt
+++ b/examples/c_wrapper/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 add_executable(c_example c_example.c elfio_c_wrapper.cpp elfio_c_wrapper.h)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR})
+target_link_libraries(c_example PRIVATE elfio::elfio)

--- a/examples/elfdump/CMakeLists.txt
+++ b/examples/elfdump/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 add_executable(elfdump elfdump.cpp)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR})
+target_link_libraries(elfdump PRIVATE elfio::elfio)

--- a/examples/tutorial/CMakeLists.txt
+++ b/examples/tutorial/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 add_executable(tutorial tutorial.cpp)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR})
+target_link_libraries(tutorial PRIVATE elfio::elfio)

--- a/examples/write_obj/CMakeLists.txt
+++ b/examples/write_obj/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 add_executable(write_obj write_obj.cpp)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR})
+target_link_libraries(write_obj PRIVATE elfio::elfio)

--- a/examples/writer/CMakeLists.txt
+++ b/examples/writer/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 add_executable(writer writer.cpp)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR})
+target_link_libraries(writer PRIVATE elfio::elfio)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,44 @@
-cmake_minimum_required(VERSION 3.12.4)
+# Unit tests are written using the Boost unit test framework
+find_package(Boost REQUIRED COMPONENTS unit_test_framework)
 
-project(ELFIOTest)
-set(CMAKE_CXX_STANDARD 11)
+# Find all the binary files used for testing and copy them into the build
+# directory. This allows the test to be run from the build directory
 
-add_executable(ELFIOTest ELFIOTest.cpp ELFIOTest1.cpp ELFIOTest2.cpp)
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/..)
+# First, create an elf_examples folder under the current build directory
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/elf_examples)
+
+# Second, glob all files under elf_examples
+file(GLOB elf_examples
+    LIST_DIRECTORIES
+        false
+    CONFIGURE_DEPENDS
+    elf_examples/*)
+
+# Third, copy each file globbed to the elf_examples folder under the current
+# build directory
+foreach(example ${elf_examples})
+    configure_file(${example} ${CMAKE_CURRENT_BINARY_DIR}/elf_examples COPYONLY)
+endforeach()
+
+# Lastly, copy the script to run the tests
+configure_file(runELFtests ${CMAKE_CURRENT_BINARY_DIR}/runELFtests COPYONLY)
+
+add_executable(
+    ELFIOTest
+    ELFIOTest.cpp
+    ELFIOTest1.cpp
+    ELFIOTest2.cpp)
+
+target_link_libraries(
+    ELFIOTest
+    PRIVATE
+        elfio::elfio
+        Boost::unit_test_framework)
+
+add_test(
+    NAME
+        ELFIOTest
+    COMMAND
+        ${CMAKE_CURRENT_BINARY_DIR}/ELFIOTest
+    WORKING_DIRECTORY
+        ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
This change adds an install step to the CMake build system. This will allow other users of CMake to easily integrate ELFIO with their projects without any extra work. This is also the first step to be able to distribute ELFIO via [vcpkg](https://github.com/microsoft/vcpkg).

The benefit of this is, after building using CMake and then running `make install` with `ELFIO` users of CMake can then use the following CMake to easily pull in ELFIO.  

```cmake
find_package(elfio REQUIRED)

add_executable(my_example_exe ....)
target_link_libraries(my_example_exe PRIVATE elfio::elfio)
```

List of changes
* Remove the setting of `CMAKE_CXX_STANDARD` to 17. elfio headers do not require C++17.
* Add options to enable building of examples and tests (off by default).
* Parse out elfio version from elfio_version.hpp
* Create a `elfio` target, which properly sets up header include paths for the examples and tests
* Install the `elfio` target to be used by external consumers of elfio
* Enable tests to run under `ctest` (so you can run `make` and then `make test`)