### PR TITLE
Setup CMake to have 'check' target like autoconf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ endif()
 
 if (ELFIO_BUILD_TESTS AND IS_TOP_PROJECT)
     enable_testing()
+    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} USES_TERMINAL)
     add_subdirectory(tests)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,4 +43,4 @@ add_test(
     WORKING_DIRECTORY
         ${CMAKE_CURRENT_BINARY_DIR})
 
-add_custom_target(check DEPENDS test)
+add_dependencies(check ELFIOTest)


### PR DESCRIPTION
This setups the CMake build system to have the same `make check`
functionality as the autoconf build system