### PR TITLE
Enabled C++11 in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,6 @@ configure_file(${version_header} ${CMAKE_CURRENT_BINARY_DIR}/elfio_version.hpp.c
 
 project(elfio VERSION ${version} LANGUAGES C CXX)
 
-# Enable C++11
-set(CMAKE_CXX_STANDARD 11)
-
 include(GNUInstallDirs)
 
 # Create a header only CMake target for elfio
@@ -40,6 +37,11 @@ target_include_directories(
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+# Enable C++11 for examples and tests
+if (ELFIO_BUILD_EXAMPLES OR ELFIO_BUILD_TESTS)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
 
 if (ELFIO_BUILD_EXAMPLES)
     add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ configure_file(${version_header} ${CMAKE_CURRENT_BINARY_DIR}/elfio_version.hpp.c
 
 project(elfio VERSION ${version} LANGUAGES C CXX)
 
+# Enable C++11
+set(CMAKE_CXX_STANDARD 11)
+
 include(GNUInstallDirs)
 
 # Create a header only CMake target for elfio


### PR DESCRIPTION
Added `set(CMAKE_CXX_STANDARD 11)` to `CMakeLists.txt` to enable C++11 support, otherwise, the build process may fail when building the examples.