### PR TITLE
Lower required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 
 # Detect if we are the top level CMakeLists.txt or are we included in some
 # other project


### PR DESCRIPTION
I don't see any feature related to CMake 3.11 or 3.12 so it should be fine to lower this requirement.

CMake 3.10 is the default version for Ubuntu 18.04 (https://packages.ubuntu.com/bionic/cmake). See also https://gitlab.kitware.com/cmake/community/-/wikis/CMake-Versions-on-Linux-Distros