### PR TITLE
Respect maximum value of size_t in set_stream_size

### DIFF
--- a/elfio/elfio_section.hpp
+++ b/elfio/elfio_section.hpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include <string>
 #include <iostream>
 #include <new>
-#include <climits>
+#include <limits>
 
 namespace ELFIO {
 
@@ -197,7 +197,7 @@ template <class T> class section_impl : public section
             set_stream_size( stream.tellg() );
         }
         else {
-            set_stream_size( ULLONG_MAX );
+            set_stream_size( std::numeric_limits<size_t>::max() );
         }
 
         stream.seekg( ( *translator )[header_offset] );

--- a/elfio/elfio_segment.hpp
+++ b/elfio/elfio_segment.hpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include <iostream>
 #include <vector>
 #include <new>
-#include <climits>
+#include <limits>
 
 namespace ELFIO {
 
@@ -168,7 +168,7 @@ template <class T> class segment_impl : public segment
             set_stream_size( stream.tellg() );
         }
         else {
-            set_stream_size( ULLONG_MAX );
+            set_stream_size( std::numeric_limits<size_t>::max() );
         }
 
         stream.seekg( ( *translator )[header_offset] );


### PR DESCRIPTION
When size_t is 32-bits (like in a WASM project), passing in a 64-bit constant leads to compile-time warnings.

This resolves #85 using the second method I suggested: passing a value of `std::numeric_limits<size_t>::max()` to set_stream_size ([see reference](https://en.cppreference.com/w/cpp/types/numeric_limits/max)).

I ran the contents of your CI test script locally:
```
cd tests
./configure
make
make check
```
The tests appeared to pass.

Please let me know if you have any questions or concerns,
Matthew