### PR TITLE
Remove semicolon at the end of the namespace definition

### DIFF
--- a/elfio/elfio_dump.hpp
+++ b/elfio/elfio_dump.hpp
@@ -1234,6 +1234,6 @@ class dump
 #undef DUMP_HEX0x_FORMAT
 #undef DUMP_STR_FORMAT
 }; // class dump
-}; // namespace ELFIO
+} // namespace ELFIO
 
 #endif // ELFIO_DUMP_HPP


### PR DESCRIPTION
Reference: https://en.cppreference.com/w/cpp/language/namespace