### PR TITLE
Stop parsing ELF if segment header is beyond end of file

### DIFF
--- a/elfio/elfio.hpp
+++ b/elfio/elfio.hpp
@@ -550,6 +550,11 @@ class elfio
             seg->load( stream,
                        static_cast<std::streamoff>( offset ) +
                            static_cast<std::streampos>( i ) * entry_size );
+
+            if ( stream.fail() ) {
+                return false;
+            }
+
             seg->set_index( i );
 
             // Add sections to the segments (similar to readelfs algorithm)


### PR DESCRIPTION
elfio::load_segments should fail the parsing of the file if the segment header is beyond the end of the file.

Resolves: #99 
Signed-off-by: Alan Jowett <alanjo@microsoft.com>