### PR TITLE
Validate that strings in table are null terminated

### DIFF
--- a/elfio/elfio_strings.hpp
+++ b/elfio/elfio_strings.hpp
@@ -46,7 +46,11 @@ template <class S> class string_section_accessor_template
             if ( index < string_section->get_size() ) {
                 const char* data = string_section->get_data();
                 if ( nullptr != data ) {
-                    return data + index;
+                    size_t string_length = strnlen(
+                        data + index, string_section->get_size() - index );
+                    if ( string_length <
+                         ( string_section->get_size() - index ) )
+                        return data + index;
                 }
             }
         }


### PR DESCRIPTION
Use strnlen to locate the end of the string (limit it to the end of the string table). Only return the string if the end of the string is entirely contained within the string table.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>