### PR TITLE
Fix sign-compare error

### DIFF
--- a/elfio/elfio_section.hpp
+++ b/elfio/elfio_section.hpp
@@ -226,7 +226,7 @@ template <class T> class section_impl : public section
                 stream.seekg(
                     ( *translator )[( *convertor )( header.sh_offset )] );
                 stream.read( data, size );
-                if (stream.gcount() != size) {
+                if (static_cast<Elf_Xword>(stream.gcount()) != size) {
                     delete[] data;
                     data = nullptr;
                     return false;

--- a/elfio/elfio_segment.hpp
+++ b/elfio/elfio_segment.hpp
@@ -185,7 +185,7 @@ template <class T> class segment_impl : public segment
 
                 if ( nullptr != data ) {
                     stream.read( data, size );
-                    if (stream.gcount() != size) {
+                    if (static_cast<Elf_Xword>(stream.gcount()) != size) {
                         delete[] data;
                         data = nullptr;
                         return false;


### PR DESCRIPTION
I just noticed that on my compiler;
probably due to recent version, not sure.