### PR TITLE
tests: allow using system gtest copy

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     googletest
     URL https://github.com/google/googletest/archive/9a32aee22d771387c494be2d8519fbdf46a713b2.zip
+    FIND_PACKAGE_ARGS NAMES GTest
 )
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings
@@ -44,7 +45,8 @@ target_link_libraries(
     ELFIOTest
     PRIVATE
     elfio::elfio
-    gtest_main)
+    gtest_main
+    GTest::gtest_main)
 
 add_test(
     NAME


### PR DESCRIPTION
Distributions often do builds with no network access available for both security reasons and also to ensure reproducibility.

This change tells CMake to query the system for a copy of gtest, but if it's not available, it'll fall back to downloading via FetchContent.