### PR TITLE
Add segment free_data function

### DIFF
--- a/elfio/elfio_segment.hpp
+++ b/elfio/elfio_segment.hpp
@@ -48,6 +48,7 @@ class segment
     ELFIO_GET_ACCESS_DECL( Elf64_Off, offset );
 
     virtual const char* get_data() const = 0;
+    virtual void free_data() const = 0;
 
     virtual Elf_Half add_section( section* psec, Elf_Xword addr_align ) = 0;
     virtual Elf_Half add_section_index( Elf_Half  index,
@@ -102,6 +103,12 @@ template <class T> class segment_impl : public segment
             load_data();
         }
         return data.get();
+    }
+
+    void free_data() const override
+    {
+        data.reset(nullptr);
+        is_lazy = true;
     }
 
     //------------------------------------------------------------------------------


### PR DESCRIPTION
Allow for segment data to be freed to allow for reduced memory usage when dealing with large elf segments.