### PR TITLE
Fix a warning shown up with clang++: -Wall -Werror -Wextra

### DIFF
--- a/elfio/elfio_modinfo.hpp
+++ b/elfio/elfio_modinfo.hpp
@@ -59,7 +59,7 @@ template <class S> class modinfo_section_accessor_template
     bool get_attribute( const std::string_view& field_name,
                         std::string&            value ) const
     {
-        for ( const auto [first, second] : content ) {
+        for ( const auto& [first, second] : content ) {
             if ( field_name == first ) {
                 value = second;
                 return true;


### PR DESCRIPTION
```
elfio/elfio_modinfo.hpp:62:26: warning: loop variable '[first, second]' creates a copy from type 'std::pair<std::basic_string<char>, std::basic_string<char>> const' [-Wrange-loop-construct]
   62 |         for ( const auto [first, second] : content ) {
      |                          ^
elfio/elfio_modinfo.hpp:62:15: note: use reference type 'std::pair<std::basic_string<char>, std::basic_string<char>> const &' to prevent copying
   62 |         for ( const auto [first, second] : content ) {
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                          &
1 warning generated.
```