### PR TITLE
Added support for ".gnu.version_d"

### DIFF
--- a/elfio/elf_types.hpp
+++ b/elfio/elf_types.hpp
@@ -1349,6 +1349,23 @@ struct Elf64_Dyn
     } d_un;
 };
 
+struct Elfxx_Verdef
+{
+    Elf_Half vd_version;
+    Elf_Half vd_flags;
+    Elf_Half vd_ndx;
+    Elf_Half vd_cnt;
+    Elf_Word vd_hash;
+    Elf_Word vd_aux;
+    Elf_Word vd_next;
+};
+
+struct Elfxx_Verdaux
+{
+    Elf_Word vda_name;
+    Elf_Word vda_next;
+};
+
 struct Elfxx_Verneed
 {
     Elf_Half vn_version;

--- a/tests/elf_examples/version_d.cpp
+++ b/tests/elf_examples/version_d.cpp
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+void print_hello_world_v1() { printf( "hello v1" ); }
+
+void print_hello_world_v2() { printf( "hello v2" ); }

--- a/tests/elf_examples/version_d.map
+++ b/tests/elf_examples/version_d.map
@@ -1,0 +1,9 @@
+HELLO_1.0 {
+  global:
+  _Z20print_hello_world_v1v;
+};
+
+HELLO_2.0 {
+global:
+_Z20print_hello_world_v2v;
+};


### PR DESCRIPTION
Hi, Serge!

Thank you for the project. It is awesome! I would like to contribute to the code with `version_d` (export version table) reader. I create a test for the code, check it for x86_64, but I don't tested it for another types ELF.

Test source can be compiled with:
```
g++ -shared -o libversion_d.so -fPIC version_d.cpp -Wl,--version-script=version_d.map
```
