### PR TITLE
Fix use-after-free when non-lazily processing corrupted sections

### DIFF
--- a/elfio/elfio.hpp
+++ b/elfio/elfio.hpp
@@ -560,6 +560,9 @@ class elfio
 
         for ( Elf_Half i = 0; i < num; ++i ) {
             section* sec = create_section();
+
+            // Load return value is ignored here
+            // This allows retrieval of information from corrupted sections
             sec->load( stream,
                        static_cast<std::streamoff>( offset ) +
                            static_cast<std::streampos>( i ) * entry_size,


### PR DESCRIPTION
Right now, return value of sec->load() is not checked on initial ELF load. However, if the stream is corrupt, it's load_data() call can fail, meaning that is_loaded flag will be left false. Despite that, problematic section will be left in the parsed data.

When reading sections after loading ELF (like in elfdump example), user might call get_data() on the section, which will in turn try to load_data() again. However, if the file was loaded non-lazily, the stream set in sec->load() will be freed by this point, thus causing a problem.

Initially I wanted to just discard corrupted sections, however, since there are test cases for corrupted elf processing, I opted to add a can_be_loaded field to section object. If load_data failed, it is set to false, thus preventing any broken reads from occuring.