### PR TITLE
ci: set minimum token permissions for the GITHUB_TOKEN

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -8,6 +8,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: CMake Build & Test

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,8 +9,15 @@ on:
   schedule:
     - cron: '0 15 * * 5'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
+    permissions:
+      actions: read  # for github/codeql-action/init to get workflow details
+      contents: read  # for actions/checkout to fetch code
+      security-events: write  # for github/codeql-action/analyze to upload SARIF results
     name: Analyze
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Hi! I used Security Step web app to help set the least token permissions for the GITHUB_TOKEN, which will be one of the best practices for workflows and is recommended by [GitHub official](https://docs.github.com/en/actions/reference/secure-use-reference#use-secrets-for-sensitive-information).