### PR TITLE
Fix: sort secitons in segment when loading

### DIFF
--- a/elfio/elfio.hpp
+++ b/elfio/elfio.hpp
@@ -632,6 +632,11 @@ class elfio
             return false;
         }
 
+        std::vector<Elf64_Addr> offsets;
+        for ( const auto &psec : sections) {
+            offsets.emplace_back( psec->get_offset() );
+        }
+
         for ( Elf_Half i = 0; i < num; ++i ) {
             if ( file_class == ELFCLASS64 ) {
                 segments_.emplace_back( new ( std::nothrow )
@@ -688,6 +693,7 @@ class elfio
                     seg->add_section_index( psec->get_index(), 0 );
                 }
             }
+            seg->sort_sections( offsets );
         }
 
         return true;

--- a/elfio/elfio_segment.hpp
+++ b/elfio/elfio_segment.hpp
@@ -111,6 +111,9 @@ class segment
     //! \brief Check if the offset is initialized
     //! \return True if the offset is initialized, false otherwise
     virtual bool is_offset_initialized() const = 0;
+    //------------------------------------------------------------------------------
+    //! \brief Sort sections in a segment according to offset
+    virtual void sort_sections( std::vector<Elf64_Addr>& offsets ) = 0;
 
   protected:
     //------------------------------------------------------------------------------
@@ -380,6 +383,14 @@ template <class T> class segment_impl : public segment
     //! \brief Set the stream size
     //! \param value Stream size
     void set_stream_size( size_t value ) { stream_size = value; }
+    //------------------------------------------------------------------------------
+    //! \brief Sort sections in a segment according to offset
+    virtual void sort_sections( std::vector<Elf64_Addr> &offsets )
+    {
+        std::sort( sections.begin(), sections.end(), [&]( Elf_Half& a, Elf_Half& b) {
+            return offsets[a] < offsets[b];
+        } );
+    }
 
     //------------------------------------------------------------------------------
   private:


### PR DESCRIPTION
### Summary 
Sort the sections in a segment when loading to support go ELF files.

### Background
Go ELF files have a section named `.note.go.buildid`, it starts before `.text` (at offset `f9c`, while `.text` start at `1000`), but its index in section table (which is `19`) is after index of `.text` (which is `1`). The `.note.go.buildid` section should be placed before `.text` but since the index is reversed, ELFIO try to place `.text` first, which cause an error in `write_segment_data`.

For now, simply loading and saving a go ELF without modifying it yields an error while saving.

### What does this PR do
Sort the sections in each segment according to their offsets.

Test passed 73/73